### PR TITLE
Export Html prop types

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -9,7 +9,7 @@ const needForceStyle = (el: HTMLDivElement) => {
   return !ok;
 };
 
-type TransformAttrs = {
+export type HtmlTransformAttrs = {
   x: number;
   y: number;
   scaleX: number;
@@ -19,11 +19,11 @@ type TransformAttrs = {
   skewY: number;
 };
 
-type Props = PropsWithChildren<{
+export type HtmlProps = PropsWithChildren<{
   groupProps?: Konva.ContainerConfig;
   divProps?: any;
   transform?: boolean;
-  transformFunc?: (attrs: TransformAttrs) => TransformAttrs;
+  transformFunc?: (attrs: HtmlTransformAttrs) => HtmlTransformAttrs;
 }>;
 
 export const Html = ({
@@ -32,7 +32,7 @@ export const Html = ({
   divProps,
   transform,
   transformFunc,
-}: Props) => {
+}: HtmlProps) => {
   const groupRef = React.useRef<Konva.Group>(null);
   const container = React.useRef<HTMLDivElement>();
 

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -1,5 +1,5 @@
 import Konva from 'konva';
-import React, { PropsWithChildren } from 'react';
+import React, {HTMLAttributes, PropsWithChildren} from 'react';
 import ReactDOM from 'react-dom/client';
 import { Group } from 'react-konva';
 
@@ -21,7 +21,7 @@ export type HtmlTransformAttrs = {
 
 export type HtmlProps = PropsWithChildren<{
   groupProps?: Konva.ContainerConfig;
-  divProps?: any;
+  divProps?: HTMLAttributes<HTMLDivElement>;
   transform?: boolean;
   transformFunc?: (attrs: HtmlTransformAttrs) => HtmlTransformAttrs;
 }>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { Html } from './html';
+export * from './html';
 export { Portal } from './portal';
 export { useImage } from './use-image';


### PR DESCRIPTION
This tiny PR will export the Html components prop types. This makes it easier to extend the Html component for example when building a wrapper to bridge contexts.

```tsx
import {Html, HtmlProps} from 'react-konva-utils';

export const HtmlWithProviders: React.FC<HtmlProps> = ({children, ...props}) => {
    const intl = useIntl();
    return (
        <Html {...props}>
            <RawIntlProvider value={intl}>{children}</RawIntlProvider>
        </Html>
    );
};
```

It also replaces the `any` on the divProps prop with the correct types.