### PR TITLE
Add handleTransform to useLayoutEffect Dependencies

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -89,7 +89,7 @@ export const Html = ({
       group.off('absoluteTransformChange', handleTransform);
       div.parentNode?.removeChild(div);
     };
-  }, [shouldTransform]);
+  }, [shouldTransform, handleTransform]);
 
   React.useLayoutEffect(() => {
     handleTransform();


### PR DESCRIPTION
This PR updates the event binding for the absoluteTransformChange event to use the latest handleTransform function. Currently, the event is only rebound when shouldTransform changes, whereas handleTransform is updated on every rerender of the Html component.

In our business case, this can cause the transformFunc props to use an outdated closure, especially if the transformFunc is not pure. For example:

```typescript
function Quickbar() {
   const scale = useBoardScale();
   .... 
   return <Html transformFunc={({ x, y, ...attrs }) => ({ x: x / scale.x, y: y / scale.y, ...attrs })} />
}
```

Thanks for the busyness, take a look at this PR
