### PR TITLE
Feat/html inherit listen

### DIFF
--- a/src/html.tsx
+++ b/src/html.tsx
@@ -20,9 +20,9 @@ export type HtmlTransformAttrs = {
 };
 
 const relevantProperties = [
-  "pointerEvents",
-  "userSelect",
-  "touchAction",
+  'pointerEvents',
+  'userSelect',
+  'touchAction',
 ] as const;
 
 export type HtmlProps = PropsWithChildren<{
@@ -59,18 +59,18 @@ export const Html = ({
 
   const disable = React.useCallback(() => {
     relevantProperties.forEach((property) => {
-      div.style[property] = "none";
+      div.style[property] = 'none';
     });
   }, []);
 
   const restore = React.useCallback(() => {
-    div.style.pointerEvents = "auto";
+    div.style.pointerEvents = 'auto';
     return;
   }, []);
 
   React.useEffect(() => {
     relevantProperties.forEach((property) => {
-      div.style[property] = "none";
+      div.style[property] = 'none';
     });
   }, []);
 


### PR DESCRIPTION
These changes allow you to have a draggable group with an inner `Html` element that can have internal pointer events.

Small example:
```tsx
<Group draggable>
  <Html selectors="input">
    <div style={{ width: '200px', height: '200px' }}>
        <input type="number" />
    </div>
  </Html>
</Group>
```
You can now drag the div and use the input field simultaneously without having to add extra css to specify the pointer events everywhere. Furthermore, the pointer events on the input can be disabled based on whether or not the parent is listening. I think this behavior is more in line with what we expect from Konva when used with HTML.