### PR TITLE
feat: automatically change opacity + visibility based on parent konva elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ import { Html } from 'react-konva-utils';
 <Html
   transform // should we apply position transform automatically to DOM container, default is true
   transformFunc={(transformAttrs) => newAttrs} // function to overwrite transformation attributes, not used if transform = false, default is undefined
+  deriveOpacity // when true, HTML dom will adjust opacity to match parent Konva elements, default is false
+  deriveVisibility // when true, HTML dom will adjust visibility to match parent Konva elements, default is false
   groupProps={{}} // additional properties to the group wrapper, useful for some position offset
   divProps={{}} // additional props for wrapped div elements, useful for styles
   parentNodeFunc={(args) => args.stage?.container()} // function to find parent node to insert content, default is stage container

--- a/src/html.tsx
+++ b/src/html.tsx
@@ -25,6 +25,10 @@ export type HtmlProps = PropsWithChildren<{
   groupProps?: Konva.ContainerConfig;
   divProps?: HTMLAttributes<HTMLDivElement>;
   transform?: boolean;
+  /** When true, the HTML dom will adjust its opacity to match the opacity of parent Konva Elements */
+  deriveOpacity?: boolean;
+  /** When true, the HTML dom will adjust its visibility to match the opacity of parent Konva Elements */
+  deriveVisibility?: boolean;
   transformFunc?: (attrs: HtmlTransformAttrs) => HtmlTransformAttrs;
   parentNodeFunc?: (args: { stage: Konva.Stage | null }) => HTMLDivElement;
 }>;
@@ -42,6 +46,8 @@ export const Html = ({
   groupProps,
   divProps,
   transform,
+  deriveOpacity,
+  deriveVisibility,
   transformFunc,
   parentNodeFunc,
 }: HtmlProps) => {
@@ -52,6 +58,10 @@ export const Html = ({
   const root = React.useMemo(() => ReactDOM.createRoot(div), [div]);
 
   const shouldTransform = transform ?? true;
+  // Following properties are false by default to avoid breaking current default behavior
+  // In a major release this should probably default to 'true'
+  const shouldDeriveOpaciy = deriveOpacity ?? false;
+  const shouldDeriveVisibility = deriveVisibility ?? false;
 
   const handleTransform = useEvent(() => {
     if (shouldTransform && groupRef.current) {
@@ -114,46 +124,54 @@ export const Html = ({
     group.on('absoluteTransformChange', handleTransform);
     handleTransform();
 
-    // Listen for opacity changes on the group and all ancestors
-    const listenToOpacity = (node: Konva.Node | null) => {
-      if (!node) return;
-      node.on('opacityChange', handleOpacityChange);
-      listenToOpacity(node.getParent());
-    };
-    listenToOpacity(group);
-    handleOpacityChange();
+    if (shouldDeriveOpaciy) {
+      // Listen for opacity changes on the group and all ancestors (recursive)
+      const listenToOpacity = (node: Konva.Node | null) => {
+        if (!node) return;
+        node.on('opacityChange', handleOpacityChange);
+        listenToOpacity(node.getParent());
+      };
+      listenToOpacity(group);
+      handleOpacityChange();
+    }
 
-    // Listen for visibility changes on the group and all ancestors
-    const listenToVisibility = (node: Konva.Node | null) => {
-      if (!node) return;
-      node.on('visibleChange', handleVisibilityChange);
-      listenToVisibility(node.getParent());
-    };
-    listenToVisibility(group);
-    handleVisibilityChange();
-
+    if (shouldDeriveVisibility) {
+      // Listen for visibility changes on the group and all ancestors (recursive)
+      const listenToVisibility = (node: Konva.Node | null) => {
+        if (!node) return;
+        node.on('visibleChange', handleVisibilityChange);
+        listenToVisibility(node.getParent());
+      };
+      listenToVisibility(group);
+      handleVisibilityChange();
+    }
+    
     return () => {
       group.off('absoluteTransformChange', handleTransform);
 
-      // Remove opacity listeners
-      const removeOpacityListeners = (node: Konva.Node | null) => {
-        if (!node) return;
-        node.off('opacityChange', handleOpacityChange);
-        removeOpacityListeners(node.getParent());
-      };
-      removeOpacityListeners(group);
+      // Remove opacity listeners from node and all ancestors
+      if (shouldDeriveOpaciy) {
+        const removeOpacityListeners = (node: Konva.Node | null) => {
+          if (!node) return;
+          node.off('opacityChange', handleOpacityChange);
+          removeOpacityListeners(node.getParent());
+        };
+        removeOpacityListeners(group);
+      }
 
-      // Remove visibility listeners
-      const removeVisibilityListeners = (node: Konva.Node | null) => {
-        if (!node) return;
-        node.off('visibleChange', handleVisibilityChange);
-        removeVisibilityListeners(node.getParent());
-      };
-      removeVisibilityListeners(group);
+      if (shouldDeriveVisibility) {
+        // Remove visibility listeners from node and all ancestors
+        const removeVisibilityListeners = (node: Konva.Node | null) => {
+          if (!node) return;
+          node.off('visibleChange', handleVisibilityChange);
+          removeVisibilityListeners(node.getParent());
+        };
+        removeVisibilityListeners(group);
+      }
 
       div.parentNode?.removeChild(div);
     };
-  }, [shouldTransform, parentNodeFunc]);
+  }, [shouldTransform, shouldDeriveOpaciy, shouldDeriveVisibility, parentNodeFunc]);
 
   React.useLayoutEffect(() => {
     handleTransform();

--- a/src/stories/html.stories.tsx
+++ b/src/stories/html.stories.tsx
@@ -1,164 +1,165 @@
-import Konva from "konva";
-import React from "react";
+import React from 'react';
 import { Group, Layer, Rect, Stage, Transformer } from "react-konva";
-import { Html } from "../html";
-import { Scene } from "./Scene";
+import Konva from "konva";
+
+import { Scene } from './Scene';
+import { Html } from '../html';
 
 export default {
-	title: "Html",
-	component: Html,
+  title: 'Html',
+  component: Html,
 };
 
 export const Default = () => (
-	<Scene>
-		<Group draggable>
-			<Rect width={100} height={100} fill="red" />
-			<Html divProps={{ style: { border: "1px solid grey" } }}>
-				Hello, world
-			</Html>
-		</Group>
-	</Scene>
+  <Scene>
+    <Group draggable>
+      <Rect width={100} height={100} fill="red" />
+      <Html divProps={{ style: { border: '1px solid grey' } }}>
+        Hello, world
+      </Html>
+    </Group>
+  </Scene>
 );
 // HtmlSt.storyName = 'Default';
 
 export const NoAutoTransform = () => (
-	<Scene>
-		<Group draggable>
-			<Rect width={100} height={100} fill="red" />
-			<Html transform={false}>Hello, world</Html>
-		</Group>
-	</Scene>
+  <Scene>
+    <Group draggable>
+      <Rect width={100} height={100} fill="red" />
+      <Html transform={false}>Hello, world</Html>
+    </Group>
+  </Scene>
 );
 // HtmlStNoTransform.storyName = 'No transform';
 
 export const Transforming = () => {
-	const groupRef = React.useRef();
-	const trRef = React.useRef();
+  const groupRef = React.useRef();
+  const trRef = React.useRef();
 
-	React.useLayoutEffect(() => {
-		trRef.current.nodes([groupRef.current]);
-	});
-	return (
-		<Scene>
-			<Group draggable ref={groupRef} x={60} y={60}>
-				<Rect width={100} height={100} fill="red" />
-				<Html>Hello, world</Html>
-			</Group>
-			<Transformer ref={trRef} />
-		</Scene>
-	);
+  React.useLayoutEffect(() => {
+    trRef.current.nodes([groupRef.current]);
+  });
+  return (
+    <Scene>
+      <Group draggable ref={groupRef} x={60} y={60}>
+        <Rect width={100} height={100} fill="red" />
+        <Html>Hello, world</Html>
+      </Group>
+      <Transformer ref={trRef} />
+    </Scene>
+  );
 };
 
 export const CalculatedTransforming = () => {
-	const groupRef = React.useRef();
-	const trRef = React.useRef();
+  const groupRef = React.useRef();
+  const trRef = React.useRef();
 
-	React.useLayoutEffect(() => {
-		trRef.current.nodes([groupRef.current]);
-	});
+  React.useLayoutEffect(() => {
+    trRef.current.nodes([groupRef.current]);
+  });
 
-	return (
-		<Scene>
-			<Group draggable ref={groupRef} x={60} y={60}>
-				<Rect width={100} height={100} fill="red" />
-				<Html transformFunc={(attrs) => ({ ...attrs, rotation: 0 })}>
-					Hello, world
-				</Html>
-			</Group>
-			<Transformer ref={trRef} />
-		</Scene>
-	);
+  return (
+    <Scene>
+      <Group draggable ref={groupRef} x={60} y={60}>
+        <Rect width={100} height={100} fill="red" />
+        <Html transformFunc={(attrs) => ({ ...attrs, rotation: 0 })}>
+          Hello, world
+        </Html>
+      </Group>
+      <Transformer ref={trRef} />
+    </Scene>
+  );
 };
 
 export const CalculatedTransformingChanging = () => {
-	const groupRef = React.useRef();
-	const trRef = React.useRef();
+  const groupRef = React.useRef();
+  const trRef = React.useRef();
 
-	const [rotation, setRotation] = React.useState(0);
+  const [rotation, setRotation] = React.useState(0);
 
-	React.useLayoutEffect(() => {
-		trRef.current.nodes([groupRef.current]);
-	});
+  React.useLayoutEffect(() => {
+    trRef.current.nodes([groupRef.current]);
+  });
 
-	React.useEffect(() => {
-		const interval = setInterval(() => {
-			setRotation((r) => r + 1);
-		}, 100);
+  React.useEffect(() => {
+    const interval = setInterval(() => {
+      setRotation((r) => r + 1);
+    }, 100);
 
-		return () => clearInterval(interval);
-	});
+    return () => clearInterval(interval);
+  });
 
-	return (
-		<Scene>
-			<Group draggable ref={groupRef} x={60} y={60}>
-				<Rect width={100} height={100} fill="red" />
-				<Html transformFunc={(attrs) => ({ ...attrs, rotation: rotation })}>
-					Hello, world
-				</Html>
-			</Group>
-			<Transformer ref={trRef} />
-		</Scene>
-	);
+  return (
+    <Scene>
+      <Group draggable ref={groupRef} x={60} y={60}>
+        <Rect width={100} height={100} fill="red" />
+        <Html transformFunc={(attrs) => ({ ...attrs, rotation: rotation })}>
+          Hello, world
+        </Html>
+      </Group>
+      <Transformer ref={trRef} />
+    </Scene>
+  );
 };
 
 export const ChangeProps = () => {
-	const [style, setStyle] = React.useState({ border: "" });
-	const [transform, setTransform] = React.useState(false);
+  const [style, setStyle] = React.useState({ border: '' });
+  const [transform, setTransform] = React.useState(false);
 
-	return (
-		<Scene>
-			<Group draggable x={60} y={60}>
-				<Rect width={100} height={100} fill="red" />
-				<Html transform={false}>
-					<button
-						onClick={() => {
-							if (style.border) {
-								setStyle({ border: "" });
-							} else {
-								setStyle({ border: "1px solid black" });
-							}
-						}}
-					>
-						toggle style
-					</button>
-					<button
-						onClick={() => {
-							setTransform(!transform);
-						}}
-					>
-						toggle transform
-					</button>
-				</Html>
-				<Html divProps={{ style }} transform={transform}>
-					Hello, world
-				</Html>
-			</Group>
-		</Scene>
-	);
+  return (
+    <Scene>
+      <Group draggable x={60} y={60}>
+        <Rect width={100} height={100} fill="red" />
+        <Html transform={false}>
+          <button
+            onClick={() => {
+              if (style.border) {
+                setStyle({ border: '' });
+              } else {
+                setStyle({ border: '1px solid black' });
+              }
+            }}
+          >
+            toggle style
+          </button>
+          <button
+            onClick={() => {
+              setTransform(!transform);
+            }}
+          >
+            toggle transform
+          </button>
+        </Html>
+        <Html divProps={{ style }} transform={transform}>
+          Hello, world
+        </Html>
+      </Group>
+    </Scene>
+  );
 };
 
-const TestContext = React.createContext({ color: "red" });
+const TestContext = React.createContext({ color: 'red' });
 
 const HtmlInternal = () => {
-	const data = React.useContext(TestContext);
-	return (
-		<div>
-			<div style={{ color: data.color }}>Hello, world, I should be green.</div>
-		</div>
-	);
+  const data = React.useContext(TestContext);
+  return (
+    <div>
+      <div style={{ color: data.color }}>Hello, world, I should be green.</div>
+    </div>
+  );
 };
 
 export const PassContext = () => {
-	return (
-		<TestContext.Provider value={{ color: "green" }}>
-			<Scene>
-				<Html>
-					<HtmlInternal />
-				</Html>
-			</Scene>
-		</TestContext.Provider>
-	);
-};
+  return (
+    <TestContext.Provider value={{ color: 'green' }}>
+      <Scene>
+        <Html>
+          <HtmlInternal />
+        </Html>
+      </Scene>
+    </TestContext.Provider>
+  );
+}
 
 export const VisibilityAndOpacityChanges = () => {
 	const topLayerRef = React.useRef<Konva.Layer>(null);

--- a/src/stories/html.stories.tsx
+++ b/src/stories/html.stories.tsx
@@ -160,10 +160,12 @@ export const PassContext = () => {
 	);
 };
 
-export const TwoLayersWithTween = () => {
+export const VisibilityAndOpacityChanges = () => {
 	const topLayerRef = React.useRef<Konva.Layer>(null);
 	const [isOpacityVisible, setIsOpacityVisible] = React.useState(true);
 	const [isVisibilityVisible, setIsVisibilityVisible] = React.useState(true);
+	const [deriveOpacity, setDeriveOpacity] = React.useState(false);
+	const [deriveVisibility, setDeriveVisibility] = React.useState(false);
 
 	const toggleOpacity = () => {
 		if (topLayerRef.current) {
@@ -189,34 +191,14 @@ export const TwoLayersWithTween = () => {
 
 	return (
 		<div>
-			<button
-				type="button"
-				onClick={toggleOpacity}
-				style={{
-					marginBottom: "10px",
-					marginRight: "10px",
-					padding: "8px 16px",
-					cursor: "pointer",
-				}}
-			>
-				Toggle Top Layer Opacity (Tween)
-			</button>
-			<button
-				type="button"
-				onClick={toggleVisibility}
-				style={{
-					marginBottom: "10px",
-					padding: "8px 16px",
-					cursor: "pointer",
-				}}
-			>
-				Toggle Top Layer Visibility
-			</button>
 			<Stage width={500} height={400}>
 				<Layer>
 					<Group x={50} y={50}>
 						<Rect width={150} height={150} fill="blue" />
-						<Html>
+						<Html
+							deriveOpacity={deriveOpacity}
+							deriveVisibility={deriveVisibility}
+						>
 							<div
 								style={{
 									padding: "10px",
@@ -233,7 +215,10 @@ export const TwoLayersWithTween = () => {
 				<Layer ref={topLayerRef}>
 					<Group x={100} y={100}>
 						<Rect width={150} height={150} fill="red" />
-						<Html>
+						<Html
+							deriveOpacity={deriveOpacity}
+							deriveVisibility={deriveVisibility}
+						>
 							<div
 								style={{
 									padding: "10px",
@@ -248,6 +233,40 @@ export const TwoLayersWithTween = () => {
 					</Group>
 				</Layer>
 			</Stage>
+
+			<div style={{ display: "flex", flexDirection: "column", gap: "12px" }}>
+				<div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+					<label>
+						<input
+							type="checkbox"
+							checked={deriveOpacity}
+							onChange={(e) => setDeriveOpacity(e.target.checked)}
+						/>
+						Auto adjust opacity{" "}
+						<code>(deriveOpacity = {deriveOpacity ? "true" : "false"})</code>
+					</label>
+					<button type="button" onClick={toggleOpacity}>
+						Toggle Top Layer Opacity (Tween)
+					</button>
+				</div>
+
+				<div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
+					<label>
+						<input
+							type="checkbox"
+							checked={deriveVisibility}
+							onChange={(e) => setDeriveVisibility(e.target.checked)}
+						/>
+						Auto Adjust visibility{" "}
+						<code>
+							(deriveVisibility = {deriveVisibility ? "true" : "false"})
+						</code>
+					</label>
+					<button type="button" onClick={toggleVisibility}>
+						Toggle Top Layer Visibility
+					</button>
+				</div>
+			</div>
 		</div>
 	);
 };

--- a/src/stories/html.stories.tsx
+++ b/src/stories/html.stories.tsx
@@ -162,11 +162,12 @@ export const PassContext = () => {
 
 export const TwoLayersWithTween = () => {
 	const topLayerRef = React.useRef<Konva.Layer>(null);
-	const [isVisible, setIsVisible] = React.useState(true);
+	const [isOpacityVisible, setIsOpacityVisible] = React.useState(true);
+	const [isVisibilityVisible, setIsVisibilityVisible] = React.useState(true);
 
 	const toggleOpacity = () => {
 		if (topLayerRef.current) {
-			const targetOpacity = isVisible ? 0 : 1;
+			const targetOpacity = isOpacityVisible ? 0 : 1;
 
 			new Konva.Tween({
 				node: topLayerRef.current,
@@ -174,7 +175,15 @@ export const TwoLayersWithTween = () => {
 				opacity: targetOpacity,
 			}).play();
 
-			setIsVisible(!isVisible);
+			setIsOpacityVisible(!isOpacityVisible);
+		}
+	};
+
+	const toggleVisibility = () => {
+		if (topLayerRef.current) {
+			const newVisibility = !isVisibilityVisible;
+			topLayerRef.current.visible(newVisibility);
+			setIsVisibilityVisible(newVisibility);
 		}
 	};
 
@@ -185,11 +194,23 @@ export const TwoLayersWithTween = () => {
 				onClick={toggleOpacity}
 				style={{
 					marginBottom: "10px",
+					marginRight: "10px",
 					padding: "8px 16px",
 					cursor: "pointer",
 				}}
 			>
-				Toggle Top Layer Opacity
+				Toggle Top Layer Opacity (Tween)
+			</button>
+			<button
+				type="button"
+				onClick={toggleVisibility}
+				style={{
+					marginBottom: "10px",
+					padding: "8px 16px",
+					cursor: "pointer",
+				}}
+			>
+				Toggle Top Layer Visibility
 			</button>
 			<Stage width={500} height={400}>
 				<Layer>

--- a/src/stories/html.stories.tsx
+++ b/src/stories/html.stories.tsx
@@ -1,161 +1,232 @@
-import React from 'react';
-import { Rect, Group, Transformer } from 'react-konva';
-
-import { Scene } from './Scene';
-import { Html } from '../html';
+import Konva from "konva";
+import React from "react";
+import { Group, Layer, Rect, Stage, Transformer } from "react-konva";
+import { Html } from "../html";
+import { Scene } from "./Scene";
 
 export default {
-  title: 'Html',
-  component: Html,
+	title: "Html",
+	component: Html,
 };
 
 export const Default = () => (
-  <Scene>
-    <Group draggable>
-      <Rect width={100} height={100} fill="red" />
-      <Html divProps={{ style: { border: '1px solid grey' } }}>
-        Hello, world
-      </Html>
-    </Group>
-  </Scene>
+	<Scene>
+		<Group draggable>
+			<Rect width={100} height={100} fill="red" />
+			<Html divProps={{ style: { border: "1px solid grey" } }}>
+				Hello, world
+			</Html>
+		</Group>
+	</Scene>
 );
 // HtmlSt.storyName = 'Default';
 
 export const NoAutoTransform = () => (
-  <Scene>
-    <Group draggable>
-      <Rect width={100} height={100} fill="red" />
-      <Html transform={false}>Hello, world</Html>
-    </Group>
-  </Scene>
+	<Scene>
+		<Group draggable>
+			<Rect width={100} height={100} fill="red" />
+			<Html transform={false}>Hello, world</Html>
+		</Group>
+	</Scene>
 );
 // HtmlStNoTransform.storyName = 'No transform';
 
 export const Transforming = () => {
-  const groupRef = React.useRef();
-  const trRef = React.useRef();
+	const groupRef = React.useRef();
+	const trRef = React.useRef();
 
-  React.useLayoutEffect(() => {
-    trRef.current.nodes([groupRef.current]);
-  });
-  return (
-    <Scene>
-      <Group draggable ref={groupRef} x={60} y={60}>
-        <Rect width={100} height={100} fill="red" />
-        <Html>Hello, world</Html>
-      </Group>
-      <Transformer ref={trRef} />
-    </Scene>
-  );
+	React.useLayoutEffect(() => {
+		trRef.current.nodes([groupRef.current]);
+	});
+	return (
+		<Scene>
+			<Group draggable ref={groupRef} x={60} y={60}>
+				<Rect width={100} height={100} fill="red" />
+				<Html>Hello, world</Html>
+			</Group>
+			<Transformer ref={trRef} />
+		</Scene>
+	);
 };
 
 export const CalculatedTransforming = () => {
-  const groupRef = React.useRef();
-  const trRef = React.useRef();
+	const groupRef = React.useRef();
+	const trRef = React.useRef();
 
-  React.useLayoutEffect(() => {
-    trRef.current.nodes([groupRef.current]);
-  });
+	React.useLayoutEffect(() => {
+		trRef.current.nodes([groupRef.current]);
+	});
 
-  return (
-    <Scene>
-      <Group draggable ref={groupRef} x={60} y={60}>
-        <Rect width={100} height={100} fill="red" />
-        <Html transformFunc={(attrs) => ({ ...attrs, rotation: 0 })}>
-          Hello, world
-        </Html>
-      </Group>
-      <Transformer ref={trRef} />
-    </Scene>
-  );
+	return (
+		<Scene>
+			<Group draggable ref={groupRef} x={60} y={60}>
+				<Rect width={100} height={100} fill="red" />
+				<Html transformFunc={(attrs) => ({ ...attrs, rotation: 0 })}>
+					Hello, world
+				</Html>
+			</Group>
+			<Transformer ref={trRef} />
+		</Scene>
+	);
 };
 
 export const CalculatedTransformingChanging = () => {
-  const groupRef = React.useRef();
-  const trRef = React.useRef();
+	const groupRef = React.useRef();
+	const trRef = React.useRef();
 
-  const [rotation, setRotation] = React.useState(0);
+	const [rotation, setRotation] = React.useState(0);
 
-  React.useLayoutEffect(() => {
-    trRef.current.nodes([groupRef.current]);
-  });
+	React.useLayoutEffect(() => {
+		trRef.current.nodes([groupRef.current]);
+	});
 
-  React.useEffect(() => {
-    const interval = setInterval(() => {
-      setRotation((r) => r + 1);
-    }, 100);
+	React.useEffect(() => {
+		const interval = setInterval(() => {
+			setRotation((r) => r + 1);
+		}, 100);
 
-    return () => clearInterval(interval);
-  });
+		return () => clearInterval(interval);
+	});
 
-  return (
-    <Scene>
-      <Group draggable ref={groupRef} x={60} y={60}>
-        <Rect width={100} height={100} fill="red" />
-        <Html transformFunc={(attrs) => ({ ...attrs, rotation: rotation })}>
-          Hello, world
-        </Html>
-      </Group>
-      <Transformer ref={trRef} />
-    </Scene>
-  );
+	return (
+		<Scene>
+			<Group draggable ref={groupRef} x={60} y={60}>
+				<Rect width={100} height={100} fill="red" />
+				<Html transformFunc={(attrs) => ({ ...attrs, rotation: rotation })}>
+					Hello, world
+				</Html>
+			</Group>
+			<Transformer ref={trRef} />
+		</Scene>
+	);
 };
 
 export const ChangeProps = () => {
-  const [style, setStyle] = React.useState({ border: '' });
-  const [transform, setTransform] = React.useState(false);
+	const [style, setStyle] = React.useState({ border: "" });
+	const [transform, setTransform] = React.useState(false);
 
-  return (
-    <Scene>
-      <Group draggable x={60} y={60}>
-        <Rect width={100} height={100} fill="red" />
-        <Html transform={false}>
-          <button
-            onClick={() => {
-              if (style.border) {
-                setStyle({ border: '' });
-              } else {
-                setStyle({ border: '1px solid black' });
-              }
-            }}
-          >
-            toggle style
-          </button>
-          <button
-            onClick={() => {
-              setTransform(!transform);
-            }}
-          >
-            toggle transform
-          </button>
-        </Html>
-        <Html divProps={{ style }} transform={transform}>
-          Hello, world
-        </Html>
-      </Group>
-    </Scene>
-  );
+	return (
+		<Scene>
+			<Group draggable x={60} y={60}>
+				<Rect width={100} height={100} fill="red" />
+				<Html transform={false}>
+					<button
+						onClick={() => {
+							if (style.border) {
+								setStyle({ border: "" });
+							} else {
+								setStyle({ border: "1px solid black" });
+							}
+						}}
+					>
+						toggle style
+					</button>
+					<button
+						onClick={() => {
+							setTransform(!transform);
+						}}
+					>
+						toggle transform
+					</button>
+				</Html>
+				<Html divProps={{ style }} transform={transform}>
+					Hello, world
+				</Html>
+			</Group>
+		</Scene>
+	);
 };
 
-const TestContext = React.createContext({ color: 'red' });
+const TestContext = React.createContext({ color: "red" });
 
 const HtmlInternal = () => {
-  const data = React.useContext(TestContext);
-  return (
-    <div>
-      <div style={{ color: data.color }}>Hello, world, I should be green.</div>
-    </div>
-  );
+	const data = React.useContext(TestContext);
+	return (
+		<div>
+			<div style={{ color: data.color }}>Hello, world, I should be green.</div>
+		</div>
+	);
 };
 
 export const PassContext = () => {
-  return (
-    <TestContext.Provider value={{ color: 'green' }}>
-      <Scene>
-        <Html>
-          <HtmlInternal />
-        </Html>
-      </Scene>
-    </TestContext.Provider>
-  );
+	return (
+		<TestContext.Provider value={{ color: "green" }}>
+			<Scene>
+				<Html>
+					<HtmlInternal />
+				</Html>
+			</Scene>
+		</TestContext.Provider>
+	);
+};
+
+export const TwoLayersWithTween = () => {
+	const topLayerRef = React.useRef<Konva.Layer>(null);
+	const [isVisible, setIsVisible] = React.useState(true);
+
+	const toggleOpacity = () => {
+		if (topLayerRef.current) {
+			const targetOpacity = isVisible ? 0 : 1;
+
+			new Konva.Tween({
+				node: topLayerRef.current,
+				duration: 1,
+				opacity: targetOpacity,
+			}).play();
+
+			setIsVisible(!isVisible);
+		}
+	};
+
+	return (
+		<div>
+			<button
+				type="button"
+				onClick={toggleOpacity}
+				style={{
+					marginBottom: "10px",
+					padding: "8px 16px",
+					cursor: "pointer",
+				}}
+			>
+				Toggle Top Layer Opacity
+			</button>
+			<Stage width={500} height={400}>
+				<Layer>
+					<Group x={50} y={50}>
+						<Rect width={150} height={150} fill="blue" />
+						<Html>
+							<div
+								style={{
+									padding: "10px",
+									background: "lightblue",
+									border: "2px solid blue",
+									borderRadius: "4px",
+								}}
+							>
+								Bottom Layer HTML
+							</div>
+						</Html>
+					</Group>
+				</Layer>
+				<Layer ref={topLayerRef}>
+					<Group x={100} y={100}>
+						<Rect width={150} height={150} fill="red" />
+						<Html>
+							<div
+								style={{
+									padding: "10px",
+									background: "lightcoral",
+									border: "2px solid red",
+									borderRadius: "4px",
+								}}
+							>
+								Top Layer HTML
+							</div>
+						</Html>
+					</Group>
+				</Layer>
+			</Stage>
+		</div>
+	);
 };


### PR DESCRIPTION
Hello and thanks for providing these utilities, I found the HTML overlay ver convenient an helpful but approached a problem with the integration when I toggled visibility and opacity of the root konva layer.
This should fix the issue and I hope it can be merged soon!

### Problem

The Html component in react-konva-utils renders DOM elements over the Konva canvas with position synchronization, but it doesn't automatically respond to opacity or visibility changes of parent Konva elements. 

This causes visual inconsistencies when:
1. Parent layers or groups have their opacity changed or animated (e.g., via Konva.Tween)
2. Parent layers or groups have their visibility toggled via .visible()

The HTML overlay remains fully visible/opaque even when the underlying Konva elements fade out or become hidden, breaking the illusion that the HTML content is part of the canvas scene.

### Solution

Added two new optional props to the Html component: `deriveOpacity` and `deriveVisibility`
Both features are opt-in to maintain backward compatibility with existing usage.

### Testing

To test the behavior of the new props, there is a new Storybook Element: `VisibilityAndOpacityChanges`, which can be used to verify the issue without the props activated and show how the props fix the issue:
<img width="902" height="525" alt="image" src="https://github.com/user-attachments/assets/8e389262-97e0-473a-aa06-c23f689e589f" />
